### PR TITLE
Fix eslintrc json format; Add env = node

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,10 @@
 {
   "parser": "@typescript-eslint/parser",
+  "env": {
+    "node": true
+  },
   "parserOptions": {
-    "ecmaVersion": "2018",
+    "ecmaVersion": 2018,
     "sourceType": "module",
     "project": "./tsconfig.json"
   },

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,70 +1,79 @@
 {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": '2018',
-    "sourceType": 'module',
-    "project": './tsconfig.json',
+    "ecmaVersion": "2018",
+    "sourceType": "module",
+    "project": "./tsconfig.json"
   },
   "plugins": ["@typescript-eslint"],
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "rules": {
-    '@typescript-eslint/indent': ['error', 2],
+    "@typescript-eslint/indent": ["error", 2],
     // Style
-    'quotes': ['error', 'single', { avoidEscape: true }],
-    'comma-dangle': ['error', 'always-multiline'], // ensures clean diffs, see https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8
-    'comma-spacing': ['error', { before: false, after: true }], // space after, no space before
-    'no-multi-spaces': ['error', { ignoreEOLComments: false }], // no multi spaces
-    'array-bracket-spacing': ['error', 'never'], // [1, 2, 3]
-    'array-bracket-newline': ['error', 'consistent'], // enforce consistent line breaks between brackets
-    'object-curly-spacing': ['error', 'always'], // { key: 'value' }
-    'object-curly-newline': ['error', { multiline: true, consistent: true }], // enforce consistent line breaks between braces
-    'object-property-newline': ['error', { allowAllPropertiesOnSameLine: true }], // enforce "same line" or "multiple line" on object properties
-    'keyword-spacing': ['error'], // require a space before & after keywords
-    'brace-style': ['error', '1tbs', { allowSingleLine: true }], // enforce one true brace style
-    'space-before-blocks': 'error', // require space before blocks
-    'curly': ['error', 'multi-line', 'consistent'], // require curly braces for multiline control statements
+    "quotes": ["error", "single", { "avoidEscape": true }],
+    "comma-dangle": ["error", "always-multiline"], // ensures clean diffs, see https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8
+    "comma-spacing": ["error", { "before": false, "after": true }], // space after, no space before
+    "no-multi-spaces": ["error", { "ignoreEOLComments": false }], // no multi spaces
+    "array-bracket-spacing": ["error", "never"], // [1, 2, 3]
+    "array-bracket-newline": ["error", "consistent"], // enforce consistent line breaks between brackets
+    "object-curly-spacing": ["error", "always"], // { key: 'value' }
+    "object-curly-newline": [
+      "error",
+      { "multiline": true, "consistent": true }
+    ], // enforce consistent line breaks between braces
+    "object-property-newline": [
+      "error",
+      { "allowAllPropertiesOnSameLine": true }
+    ], // enforce "same line" or "multiple line" on object properties
+    "keyword-spacing": ["error"], // require a space before & after keywords
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }], // enforce one true brace style
+    "space-before-blocks": "error", // require space before blocks
+    "curly": ["error", "multi-line", "consistent"], // require curly braces for multiline control statements
 
     // Cannot import from the same module twice
-    'no-duplicate-imports': ['error'],
+    "no-duplicate-imports": ["error"],
 
     // Cannot shadow names
-    'no-shadow': ['off'],
-    '@typescript-eslint/no-shadow': ['error'],
+    "no-shadow": ["off"],
+    "@typescript-eslint/no-shadow": ["error"],
 
     // Required spacing in property declarations (copied from TSLint, defaults are good)
-    'key-spacing': ['error'],
+    "key-spacing": ["error"],
 
     // Require semicolons
-    'semi': ['error', 'always'],
+    "semi": ["error", "always"],
 
     // Don't unnecessarily quote properties
-    'quote-props': ['error', 'consistent-as-needed'],
+    "quote-props": ["error", "consistent-as-needed"],
 
     // No multiple empty lines
-    'no-multiple-empty-lines': ['error'],
+    "no-multiple-empty-lines": ["error"],
 
     // Max line lengths
-    'max-len': ['error', {
-      code: 150,
-      ignoreUrls: true, // Most common reason to disable it
-      ignoreStrings: true, // These are not fantastic but necessary for error messages
-      ignoreTemplateLiterals: true,
-      ignoreComments: true,
-      ignoreRegExpLiterals: true,
-    }],
+    "max-len": [
+      "error",
+      {
+        "code": 150,
+        "ignoreUrls": true, // Most common reason to disable it
+        "ignoreStrings": true, // These are not fantastic but necessary for error messages
+        "ignoreTemplateLiterals": true,
+        "ignoreComments": true,
+        "ignoreRegExpLiterals": true
+      }
+    ],
 
     // One of the easiest mistakes to make
-    '@typescript-eslint/no-floating-promises': ['error'],
+    "@typescript-eslint/no-floating-promises": ["error"],
 
     // Make sure that inside try/catch blocks, promises are 'return await'ed
     // (must disable the base rule as it can report incorrect errors)
-    'no-return-await': 'off',
-    '@typescript-eslint/return-await': 'error',
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": "error",
 
     // Useless diff results
-    'no-trailing-spaces': ['error'],
+    "no-trailing-spaces": ["error"],
 
     // Must use foo.bar instead of foo['bar'] if possible
-    'dot-notation': ['error']
+    "dot-notation": ["error"]
   }
 }


### PR DESCRIPTION
Hi folks,

`.eslintrc` shows following warnings

<img width="1205" alt="Screenshot 2022-12-08 at 17 56 42" src="https://user-images.githubusercontent.com/1225343/206515248-d78ee866-7436-4249-abc2-f950ecf5827a.png">

I fixed it by running prettier.
Please check and let me know if this makes sense.

Thank you

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
